### PR TITLE
Start with

### DIFF
--- a/pipeline/apiserv/main.go
+++ b/pipeline/apiserv/main.go
@@ -163,6 +163,7 @@ func appsEndpoint(w http.ResponseWriter, r *http.Request) {
 		genres := []string{""}
 		permissions := []string{""}
 		appIDs := []string{""}
+		startsWith := []string{""}
 
 		util.Log.Info("Parsing app form parameters, params size %s", fmt.Sprint(len(r.Form)))
 
@@ -206,6 +207,10 @@ func appsEndpoint(w http.ResponseWriter, r *http.Request) {
 				util.Log.Debug("titles:", len(val))
 				titles = val
 
+			case "startsWith":
+				fmt.Println(val)
+				startsWith = val
+
 			case "developer":
 				developers = val
 
@@ -228,7 +233,7 @@ func appsEndpoint(w http.ResponseWriter, r *http.Request) {
 
 		util.Log.Debug("Gathering full details")
 
-		results, err := db.QuickQuery(onlyAnalyzed, store, limit, offset, developers, genres, permissions, appIDs, titles)
+		results, err := db.QuickQuery(onlyAnalyzed, store, limit, offset, developers, genres, permissions, appIDs, titles, startsWith)
 
 		if err != nil {
 			util.Log.Err("Error querying database: ", err.Error())

--- a/pipeline/apiserv/main.go
+++ b/pipeline/apiserv/main.go
@@ -293,7 +293,7 @@ func altAppsEndpoint(w http.ResponseWriter, r *http.Request) {
 }
 
 var cfgFile = flag.String("cfg", "/etc/xray/config.json", "config file location")
-var port = flag.Uint("port", 8123, "Port to serve on.")
+var port = flag.Uint("port", 8118, "Port to serve on.")
 
 func init() {
 	util.LoadCfg(*cfgFile, util.APIServ)

--- a/pipeline/db/db.go
+++ b/pipeline/db/db.go
@@ -499,6 +499,12 @@ func percentifyArray(arr *[]string) {
 	}
 }
 
+func percentifyStartifyArrayify(arr *[]string) {
+	for i, v := range *arr {
+		(*arr)[i] = v + "%"
+	}
+}
+
 var appStoreTable = map[string]string{
 	"play": "playstore_apps",
 }
@@ -506,7 +512,7 @@ var appStoreTable = map[string]string{
 // QuickQuery depricates all of dean's queries.
 func QuickQuery(
 	onlyAnalyzed bool, appStore string, limit string, offset string, developers []string,
-	genres []string, permissions []string, appIDs []string, titles []string,
+	genres []string, permissions []string, appIDs []string, titles []string, startsWith []string,
 ) ([]AppVersion, error) {
 
 	var shouldAnalyze string
@@ -533,18 +539,20 @@ func QuickQuery(
 		//+ "NATURAL JOIN app_perms " + "NATURAL JOIN app_packages"
 		"WHERE a.title ILIKE ANY($1) AND d.name ILIKE ANY($2) AND a.genre ILIKE ANY($3) " +
 		//" AND LOWER(app_perms.permissions) like any " + percentifyArray(permissions) + //TODO: s a array so need to check the arrays...
-		"AND v.app ILIKE ANY($4) " + shouldAnalyze + "LIMIT $5 OFFSET $6"
+		"AND v.app ILIKE ANY($4) AND a.title ILIKE ANY($5) " + shouldAnalyze + "LIMIT $6 OFFSET $7"
 
 	percentifyArray(&titles)
 	percentifyArray(&developers)
 	percentifyArray(&genres)
 	percentifyArray(&appIDs)
+	percentifyStartifyArrayify(&startsWith)
 
 	args := []interface{}{
 		pq.Array(&titles),
 		pq.Array(&developers),
 		pq.Array(&genres),
 		pq.Array(&appIDs),
+		pq.Array(&startsWith),
 		limit,
 		offset,
 	}


### PR DESCRIPTION
Added a ```?startsWith=``` to the API.

So a Query like this
```
	/api/apps/?startsWith=f&title=book&onlyAnalyzed=false
```
would return apps starting with ```f``` and contain ```book``` somewhere

```
[
	{
		"title":"Facebook",
		"app":"com.facebook.katana"
	},
	{
		"title":"Facebook Pages Manager",
		"app":"com.facebook.pages.app"
	},
	{
		"title":"Facebook Ads Manager",
		"app":"com.facebook.adsmanager"
	},
	{
		"title":"Facebook Mentions",
		"app":"com.facebook.Ment
	}
]
```